### PR TITLE
Add python import for RegEx

### DIFF
--- a/lib/main.py
+++ b/lib/main.py
@@ -1,7 +1,7 @@
 import os
 import subprocess
 import configparser
-
+import re
 
 def find_ansible_config_file():
     cfg_files = []


### PR DESCRIPTION
Great plugin!
Getting issues when using the vault encryption. Works fine when importing the regex lib.

Relevant Nvim conf:
```
call plug#begin('~/.local/share/nvim/plugged')
Plug 'danihodovic/vim-ansible-vault'
call plug#end()


function EncryptVault()
  :AnsibleVaultEncrypt
  edit
endfunction

nnoremap <Leader>ve :call EncryptVault() <CR>
nnoremap <Leader>vd :AnsibleVaultDecrypt <CR> :edit <CR>
```